### PR TITLE
アプリを起動せず継続的に位置情報を取得するように実装

### DIFF
--- a/MapBoxTest.xcodeproj/project.pbxproj
+++ b/MapBoxTest.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		96667FFB2446CAAE00661E91 /* LocalNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96667FFA2446CAAE00661E91 /* LocalNotificationManager.swift */; };
 		A47DC62E2443FAF100D12922 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47DC62D2443FAF100D12922 /* AppDelegate.swift */; };
 		A47DC6302443FAF100D12922 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47DC62F2443FAF100D12922 /* SceneDelegate.swift */; };
 		A47DC6322443FAF100D12922 /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47DC6312443FAF100D12922 /* MapViewController.swift */; };
@@ -35,6 +36,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		96667FFA2446CAAE00661E91 /* LocalNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationManager.swift; sourceTree = "<group>"; };
 		A47DC62A2443FAF100D12922 /* MapBoxTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MapBoxTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A47DC62D2443FAF100D12922 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A47DC62F2443FAF100D12922 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -60,6 +62,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		96667FF92446CA8D00661E91 /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				96667FFA2446CAAE00661E91 /* LocalNotificationManager.swift */,
+			);
+			path = Manager;
+			sourceTree = "<group>";
+		};
 		A47DC6212443FAF100D12922 = {
 			isa = PBXGroup;
 			children = (
@@ -80,6 +90,7 @@
 		A47DC62C2443FAF100D12922 /* MapBoxTest */ = {
 			isa = PBXGroup;
 			children = (
+				96667FF92446CA8D00661E91 /* Manager */,
 				A47DC62D2443FAF100D12922 /* AppDelegate.swift */,
 				A47DC62F2443FAF100D12922 /* SceneDelegate.swift */,
 				A47DC6312443FAF100D12922 /* MapViewController.swift */,
@@ -197,6 +208,7 @@
 			files = (
 				A47DC6322443FAF100D12922 /* MapViewController.swift in Sources */,
 				A47DC62E2443FAF100D12922 /* AppDelegate.swift in Sources */,
+				96667FFB2446CAAE00661E91 /* LocalNotificationManager.swift in Sources */,
 				A47DC6302443FAF100D12922 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MapBoxTest.xcodeproj/project.pbxproj
+++ b/MapBoxTest.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9645D4982447F01500737631 /* MBCLLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9645D4972447F01500737631 /* MBCLLocationManager.swift */; };
+		9645D49B2447F06C00737631 /* MBCLLocationManagerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9645D49A2447F06C00737631 /* MBCLLocationManagerDelegate.swift */; };
 		96667FFB2446CAAE00661E91 /* LocalNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96667FFA2446CAAE00661E91 /* LocalNotificationManager.swift */; };
 		A47DC62E2443FAF100D12922 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47DC62D2443FAF100D12922 /* AppDelegate.swift */; };
 		A47DC6302443FAF100D12922 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47DC62F2443FAF100D12922 /* SceneDelegate.swift */; };
@@ -36,6 +38,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		9645D4972447F01500737631 /* MBCLLocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBCLLocationManager.swift; sourceTree = "<group>"; };
+		9645D49A2447F06C00737631 /* MBCLLocationManagerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBCLLocationManagerDelegate.swift; sourceTree = "<group>"; };
 		96667FFA2446CAAE00661E91 /* LocalNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationManager.swift; sourceTree = "<group>"; };
 		A47DC62A2443FAF100D12922 /* MapBoxTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MapBoxTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A47DC62D2443FAF100D12922 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -62,10 +66,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9645D4992447F04B00737631 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				9645D49A2447F06C00737631 /* MBCLLocationManagerDelegate.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
 		96667FF92446CA8D00661E91 /* Manager */ = {
 			isa = PBXGroup;
 			children = (
 				96667FFA2446CAAE00661E91 /* LocalNotificationManager.swift */,
+				9645D4972447F01500737631 /* MBCLLocationManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -90,6 +103,7 @@
 		A47DC62C2443FAF100D12922 /* MapBoxTest */ = {
 			isa = PBXGroup;
 			children = (
+				9645D4992447F04B00737631 /* Protocol */,
 				96667FF92446CA8D00661E91 /* Manager */,
 				A47DC62D2443FAF100D12922 /* AppDelegate.swift */,
 				A47DC62F2443FAF100D12922 /* SceneDelegate.swift */,
@@ -139,6 +153,7 @@
 		A47DC6222443FAF100D12922 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				CLASSPREFIX = MB;
 				LastSwiftUpdateCheck = 1120;
 				LastUpgradeCheck = 1120;
 				ORGANIZATIONNAME = Prageeth;
@@ -207,7 +222,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				A47DC6322443FAF100D12922 /* MapViewController.swift in Sources */,
+				9645D49B2447F06C00737631 /* MBCLLocationManagerDelegate.swift in Sources */,
 				A47DC62E2443FAF100D12922 /* AppDelegate.swift in Sources */,
+				9645D4982447F01500737631 /* MBCLLocationManager.swift in Sources */,
 				96667FFB2446CAAE00661E91 /* LocalNotificationManager.swift in Sources */,
 				A47DC6302443FAF100D12922 /* SceneDelegate.swift in Sources */,
 			);

--- a/MapBoxTest/AppDelegate.swift
+++ b/MapBoxTest/AppDelegate.swift
@@ -77,7 +77,7 @@ extension AppDelegate: CLLocationManagerDelegate {
         LocalNotificationManager.sendLocalNotification(title: "位置情報の更新を開始します",
                                                        body: "あなた現在の位置情報 - lat: " + lat + ",lon: " + lon,
                                                        timeInterval: 5,
-                                                       isRepeats: true,
+                                                       isRepeats: false,
                                                        identifier: "didUpdateLocationsIdentifier") {
                                                         (error) in
                                                         if error != nil {

--- a/MapBoxTest/AppDelegate.swift
+++ b/MapBoxTest/AppDelegate.swift
@@ -67,6 +67,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 extension AppDelegate: CLLocationManagerDelegate {
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        // デバッグモードでローカル通知を送付する
+        #if DEBUG
         var lat = ""
         var lon = ""
         
@@ -75,7 +77,7 @@ extension AppDelegate: CLLocationManagerDelegate {
             lon = String(format: "%.2f", myLocations.coordinate.longitude)
         }
         LocalNotificationManager.sendLocalNotification(title: "位置情報の更新を開始します",
-                                                       body: "あなた現在の位置情報 - lat: " + lat + ",lon: " + lon,
+                                                       body: "あなた現在の位置情報 - lat: " + lat + ", lon: " + lon,
                                                        timeInterval: 5,
                                                        isRepeats: false,
                                                        identifier: "didUpdateLocationsIdentifier") {
@@ -84,6 +86,7 @@ extension AppDelegate: CLLocationManagerDelegate {
                                                             print(error?.localizedDescription ?? "")
                                                         }
         }
+        #endif
     }
     
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {

--- a/MapBoxTest/AppDelegate.swift
+++ b/MapBoxTest/AppDelegate.swift
@@ -54,11 +54,28 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     private func requestLocalNotificationAuth() {
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert,
-                                                                          .sound,
-                                                                          .badge])
-        { (acceped, error) in
-            if !acceped {
+        var options: UNAuthorizationOptions
+        
+        // iOS12以降の場合お試しプッシュ通知を送る
+        if #available(iOS 12.0, *) {
+            options = [.alert, .sound, .badge, .provisional]
+        } else {
+            options = [.alert, .sound, .badge]
+        }
+        
+        UNUserNotificationCenter.current().requestAuthorization(options: options) { (isAcceped, error) in
+            guard error == nil else {
+                print(error?.localizedDescription ?? "Unknown Error")
+                return
+            }
+            
+            if isAcceped {
+                // 同意された場合
+                DispatchQueue.main.async {
+                    UIApplication.shared.registerForRemoteNotifications()
+                }
+            } else {
+                // 拒否された場合
                 print("ローカル通知は拒否された")
             }
         }

--- a/MapBoxTest/AppDelegate.swift
+++ b/MapBoxTest/AppDelegate.swift
@@ -12,18 +12,17 @@ import UserNotifications
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-    var locationManager: CLLocationManager = CLLocationManager()
+    
+    /// 位置情報を管理するマネージャー
+    private var locationManager: MBCLLocationManager = MBCLLocationManager.shared
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
-        startRequestLocation()
+        locationManager.startRequestLocation()
         requestLocalNotificationAuth()
         
-        locationManager.delegate = self
-        
         if let _ = launchOptions?[UIApplication.LaunchOptionsKey.location] {
-            // 位置情報の取得を開始する
+            // 位置情報の更新を開始する
             locationManager.startUpdatingLocation()
         }
         
@@ -33,24 +32,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // MARK: UISceneSession Lifecycle
 
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        // Called when a new scene session is being created.
-        // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-    }
-
-    private func startRequestLocation() {
-        
-        locationManager.allowsBackgroundLocationUpdates = true
-        // 位置情報の取得を開始する
-        locationManager.startUpdatingLocation()
-        // 位置情報の取得を維持するように
-        locationManager.startMonitoringSignificantLocationChanges()
     }
     
     private func requestLocalNotificationAuth() {
@@ -78,47 +63,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 // 拒否された場合
                 print("ローカル通知は拒否された")
             }
-        }
-    }
-}
-
-extension AppDelegate: CLLocationManagerDelegate {
-    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        // デバッグモードでローカル通知を送付する
-        #if DEBUG
-        var lat = ""
-        var lon = ""
-        
-        if let myLocations = locations.first {
-            lat = String(format: "%.2f", myLocations.coordinate.latitude)
-            lon = String(format: "%.2f", myLocations.coordinate.longitude)
-        }
-        LocalNotificationManager.sendLocalNotification(title: "位置情報の更新を開始します",
-                                                       body: "あなた現在の位置情報 - lat: " + lat + ", lon: " + lon,
-                                                       timeInterval: 5,
-                                                       isRepeats: false,
-                                                       identifier: "didUpdateLocationsIdentifier") {
-                                                        (error) in
-                                                        if error != nil {
-                                                            print(error?.localizedDescription ?? "")
-                                                        }
-        }
-        #endif
-    }
-    
-    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        switch status {
-        case .authorizedWhenInUse:
-            locationManager.requestAlwaysAuthorization()
-        case .authorizedAlways:
-            startRequestLocation()
-            break
-        case .notDetermined:
-            break
-        case .restricted:
-            break
-        default:
-            break
         }
     }
 }

--- a/MapBoxTest/Info.plist
+++ b/MapBoxTest/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Shows your location on the map and helps improve the map.</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>Shows your location on the map and helps improve the map.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -20,6 +24,10 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>MGLMapboxAccessToken</key>
+	<string>pk.eyJ1IjoicHJhZ2VldGhtYXBib3giLCJhIjoiY2s4eHNzN3dyMTFoaDNtcGt2OWdkdG1wcCJ9.o40Xl_B4HLGMseaagAgfGQ</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Shows your location on the map and helps improve the map.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -39,6 +47,10 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -60,9 +72,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>MGLMapboxAccessToken</key>
-	<string>pk.eyJ1IjoicHJhZ2VldGhtYXBib3giLCJhIjoiY2s4eHNzN3dyMTFoaDNtcGt2OWdkdG1wcCJ9.o40Xl_B4HLGMseaagAgfGQ</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Shows your location on the map and helps improve the map.</string>
 </dict>
 </plist>

--- a/MapBoxTest/Info.plist
+++ b/MapBoxTest/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>Shows your location on the map and helps improve the map.</string>
-	<key>NSLocationAlwaysUsageDescription</key>
-	<string>Shows your location on the map and helps improve the map.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -26,6 +22,10 @@
 	<true/>
 	<key>MGLMapboxAccessToken</key>
 	<string>pk.eyJ1IjoicHJhZ2VldGhtYXBib3giLCJhIjoiY2s4eHNzN3dyMTFoaDNtcGt2OWdkdG1wcCJ9.o40Xl_B4HLGMseaagAgfGQ</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Shows your location on the map and helps improve the map.</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>Shows your location on the map and helps improve the map.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Shows your location on the map and helps improve the map.</string>
 	<key>UIApplicationSceneManifest</key>

--- a/MapBoxTest/Manager/LocalNotificationManager.swift
+++ b/MapBoxTest/Manager/LocalNotificationManager.swift
@@ -1,0 +1,36 @@
+//
+//  LocalNotificationManager.swift
+//  MapBoxTest
+//
+//  Created by setsu on 2020/04/15.
+//  Copyright © 2020 Prageeth. All rights reserved.
+//
+
+import Foundation
+import UserNotifications
+
+class LocalNotificationManager {
+    
+    // ローカル通知を設定する
+    class func sendLocalNotification(title: String?,
+                                     body: String?,
+                                     timeInterval: TimeInterval,
+                                     isRepeats: Bool,
+                                     identifier: String,
+                                     completionHandler: @escaping (Error?) -> Void) {
+        let content = UNMutableNotificationContent()
+        if let title = title {
+            content.title = title
+        }
+        
+        if let body = body {
+            content.body = body
+        }
+        
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval, repeats: isRepeats)
+        
+        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+        
+        UNUserNotificationCenter.current().add(request, withCompletionHandler: completionHandler)
+    }
+}

--- a/MapBoxTest/Manager/MBCLLocationManager.swift
+++ b/MapBoxTest/Manager/MBCLLocationManager.swift
@@ -1,0 +1,96 @@
+//
+//  MBCLLocationManager.swift
+//  MapBoxTest
+//
+//  Created by setsu on 2020/04/16.
+//  Copyright © 2020 Prageeth. All rights reserved.
+//
+
+import Foundation
+import CoreLocation
+
+final class MBCLLocationManager: NSObject {
+    
+    // MARK: - Constants
+    
+    private let clLocationManager: CLLocationManager = CLLocationManager()
+    
+    // MARK: - Variables
+    
+    static var shared: MBCLLocationManager = MBCLLocationManager()
+    var delegate: MBCLLocationManagerDelegate?
+    
+    // MARK: - Methods
+    
+    /// 初期化
+    private override init() {
+        super.init()
+        clLocationManager.delegate = self
+    }
+    
+    /// 位置情報の取得を開始する
+    func startRequestLocation() {
+        clLocationManager.allowsBackgroundLocationUpdates = true
+        // 位置情報の取得を開始する
+        clLocationManager.startUpdatingLocation()
+        // 位置情報の取得を維持するように
+        clLocationManager.startMonitoringSignificantLocationChanges()
+    }
+    
+    /// 位置情報の更新を開始するメソッド
+    func startUpdatingLocation() {
+        clLocationManager.startUpdatingLocation()
+    }
+}
+
+// MARK: - CLLocationManagerDelegate Methods
+
+extension MBCLLocationManager: CLLocationManagerDelegate {
+    
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        // デバッグモードでローカル通知を送付する
+        #if DEBUG
+        var lat = ""
+        var lon = ""
+        
+        if let myLocations = locations.first {
+            lat = String(format: "%.2f", myLocations.coordinate.latitude)
+            lon = String(format: "%.2f", myLocations.coordinate.longitude)
+        }
+        LocalNotificationManager.sendLocalNotification(title: "位置情報の更新を開始します",
+                                                       body: "あなた現在の位置情報 - 緯度: " + lat + ", 経度: " + lon,
+                                                       timeInterval: 5,
+                                                       isRepeats: false,
+                                                       identifier: "didUpdateLocationsIdentifier") {
+                                                        (error) in
+                                                        if error != nil {
+                                                            print(error?.localizedDescription ?? "")
+                                                        }
+        }
+        #endif
+    }
+    
+    func locationManager(_ manager: CLLocationManager,
+                         didChangeAuthorization status: CLAuthorizationStatus) {
+        
+        switch status {
+        case .authorizedWhenInUse:
+            // 一回限り・使用中のみ許可の場合
+            clLocationManager.requestAlwaysAuthorization()
+        case .authorizedAlways:
+            // 常に許可の場合
+            self.startRequestLocation()
+        case .notDetermined:
+            break
+        case .restricted:
+            break
+        default:
+            break
+        }
+    }
+}
+
+// MARK: - MBCLLocationManagerDelegate Methods
+extension MBCLLocationManager: MBCLLocationManagerDelegate {
+    
+}

--- a/MapBoxTest/Protocol/MBCLLocationManagerDelegate.swift
+++ b/MapBoxTest/Protocol/MBCLLocationManagerDelegate.swift
@@ -1,0 +1,14 @@
+//
+//  MBCLLocationManagerDelegate.swift
+//  MapBoxTest
+//
+//  Created by setsu on 2020/04/16.
+//  Copyright © 2020 Prageeth. All rights reserved.
+//
+
+import Foundation
+import CoreLocation
+
+protocol MBCLLocationManagerDelegate: CLLocationManagerDelegate {
+    
+}


### PR DESCRIPTION
# 概要
・アプリを起動せず継続的に位置情報を取得する

# 対応内容
・アプリを起動しない状態で継続的に位置情報を取得するよう

# 結果
・アプリを起動しない状態で継続的に位置情報を取得できるようになった

# テスト方法
1.アプリを起動し、位置情報許可を与えること
2.アプリをキルして、5秒後位置情報を含むローカル通知が来るかを確かめる

# 見てほしい点
・不要な実装は入っているか
・ネーミングは正しいか